### PR TITLE
Update command name

### DIFF
--- a/needsourcing/pbcopy.source
+++ b/needsourcing/pbcopy.source
@@ -2,8 +2,8 @@
 
 if [ "$(uname)" != Darwin ]
 then
-	alias pbcopy='xclip -selection clipboard'
-	alias pbpaste='xclip -selection clipboard -o'
+	alias cbcopy='xclip -selection clipboard'
+	alias cbpaste='xclip -selection clipboard -o'
 fi
 
 linepbcopy() { tr -d \\\n | pbcopy; }


### PR DESCRIPTION
In most linux distribution the service which handle `copy` and `paste` action it's called the *Clipboard*, so it make f*ck*ng more sense to name it that way